### PR TITLE
Update advisory parsing according to csaf protocol

### DIFF
--- a/csaf/analyser.py
+++ b/csaf/analyser.py
@@ -164,7 +164,11 @@ class CSAFAnalyser:
         if "notes" in self.data["document"]:
             for note in self.data["document"]["notes"]:
                 # Notes can be multi-line. Split text up across multiple lines
-                self._multiline(note["title"], note["text"])
+                # category and text are mandatory.
+                if "title" not in note:
+                    self._multiline(note["category"],note["text"])
+                else:
+                    self._multiline(note["title"], note["text"])
         if "publisher" in self.data["document"]:
             publisher_info = (
                 f"{self.data['document']['publisher']['name']} "

--- a/csaf/parser.py
+++ b/csaf/parser.py
@@ -49,7 +49,9 @@ class CSAFParser:
         if "notes" in document:
             notes = []
             for note in document["notes"]:
-                note_ref = {'title': note["title"], 'text' : note['text'], 'category': note['category']}
+                note_ref = {'text' : note['text'], 'category': note['category']}
+                if "title" in note:
+                    note_ref['title']=note["title"]
                 notes.append(note_ref)
             self.metadata["notes"] = notes
         if "publisher" in document:
@@ -173,7 +175,7 @@ class CSAFParser:
                         vuln_info.set_value("created", flag["date"])
                     for product in flag["product_ids"]:
                         products.append(product)
-                        vuln_info.set_value("Product", products)
+                        vuln_info.set_value("product", products)
             if "ids" in vulnerability:
                 for id in vulnerability["ids"]:
                     vuln_info.set_value("system_name", vulnerability["text"])

--- a/csaf/parser.py
+++ b/csaf/parser.py
@@ -165,12 +165,15 @@ class CSAFParser:
             if "discovery_date" in vulnerability:
                 vuln_info.set_value("discovery_date", vulnerability["discovery_date"])
             if "flags" in vulnerability:
+                products = []
                 for flag in vulnerability["flags"]:
                     if "label" in flag:
                         vuln_info.set_value("justification", flag["label"])
-                    vuln_info.set_value("created", flag["date"])
+                    if "date" in flag:
+                        vuln_info.set_value("created", flag["date"])
                     for product in flag["product_ids"]:
-                        vuln_info.set_value("Product", product)
+                        products.append(product)
+                        vuln_info.set_value("Product", products)
             if "ids" in vulnerability:
                 for id in vulnerability["ids"]:
                     vuln_info.set_value("system_name", vulnerability["text"])

--- a/csaf/parser.py
+++ b/csaf/parser.py
@@ -156,7 +156,8 @@ class CSAFParser:
         vuln_info = Vulnerability(validation="csaf")
         for vulnerability in self.data["vulnerabilities"]:
             vuln_info.initialise()
-            vuln_info.set_id(vulnerability["cve"])
+            if "cve" in vulnerability:
+                vuln_info.set_id(vulnerability["cve"])
             if "title" in vulnerability:
                 vuln_info.set_value("title", vulnerability["title"])
             if "cwe" in vulnerability:


### PR DESCRIPTION
correcting the library for missing code for getting date, title and product id of advisory
- `title` in Notes Type should be optional.  Ref:https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#633-missing-cve 
- `date` in `vulnerability` should be optional. Ref: https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#3235-vulnerabilities-property---flags
- product id should be in an array and not be single entity.Reference: https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#3235-vulnerabilities-property---flags
