### PR TITLE
Combine multiple remediations

### DIFF
--- a/csaf/parser.py
+++ b/csaf/parser.py
@@ -196,9 +196,10 @@ class CSAFParser:
                 for product_status in vulnerability["product_status"]:
                     vuln_info.set_value("status", product_status)
             if "remediations" in vulnerability:
+                remediations = []
                 for remediation in vulnerability["remediations"]:
-                    vuln_info.set_remediation(remediation["category"])
-                    vuln_info.set_action(remediation["details"])
+                    remediations.append(remediation["details"])
+                vuln_info.set_value("remediations", remediations)
             self.vulnerabilities.append(vuln_info.get_vulnerability())
 
     def get_metadata(self):


### PR DESCRIPTION
### Description

Previously remediations of vulnerability were not appended (only last remediation was stored). 
So, this pr combines `details` of all the remediations (regardless of the category: mitigation, no_fix_planned, none_available, vendor_fix, workaround) of a vulnerability and sets it in `remediations` key.

Upstream pr: https://github.com/anthonyharrison/csaf/pull/6